### PR TITLE
Adding `where` clause to joined queries

### DIFF
--- a/lib/drivers/prototype.js
+++ b/lib/drivers/prototype.js
@@ -148,6 +148,7 @@ module.exports = {
         joinString)
 
       const statement = joinStatement
+        + this.whereSql(table, conds)
         + this.orderSql(table, opts.order)
         + this.limitSql(opts.limit, opts.page)
 

--- a/test/4-get.test.js
+++ b/test/4-get.test.js
@@ -60,10 +60,79 @@ test('table.get, complex where', function (t) {
   })
 })
 
+test('table.get, relationships', function (t) {
+  useDb(t, ['user', 'book'], function (db, done) {
+    const user = makeUserTable(db)
+    const book = makeBookTable(db)
+
+    book.get({}, {
+      debug: true,
+      relationships: true
+    }, function (err, allBooks) {
+      t.notOk(err, 'no errors')
+      t.equal(allBooks.length, 17, 'all books accounted for')
+
+      book.get({ author_id: 1 }, {
+        debug: true,
+        relationships: true
+      }, function (err, someBooks) {
+        t.notOk(err, 'no errors')
+        t.ok(someBooks.length < allBooks.length, 'query returns subset of books')
+        t.equal(someBooks.length, 6, 'all requested books accounted for')
+        t.end()
+      })
+    })
+  })
+})
+
+test('table.get, relationships', function (t) {
+  useDb(t, ['user', 'book'], function (db, done) {
+    const user = makeUserTable(db)
+    const book = makeBookTable(db)
+
+    user.getOne({ id: 1 }, {
+      debug: true,
+      relationships: true
+    }, function (err, author) {
+      t.notOk(err, 'no errors')
+      t.equal(author.last_name, 'Saunders', 'We\'ve found Mr Saunders')
+
+      book.get({ author_id: 1 }, {
+        debug: true,
+      }, function (err, books) {
+        t.notOk(err, 'no errors')
+        t.equal(author.books.length, books.length, 'All of author\'s books found correctly')
+        t.end()
+      })
+    })
+  })
+})
+
 function value(name) { return function (obj) { return obj[name] } }
 
 function makeUserTable(db) {
   return db.table('user', {
     fields: ['first_name', 'last_name', 'age'],
+    relationships: {
+      books: {
+        type: 'hasMany',
+        local: 'id',
+        foreign: { table: 'book', key: 'author_id' },
+        optional: true,
+      }
+    },
+  })
+}
+
+function makeBookTable(db) {
+  return db.table('book', {
+    fields: [ 'id', 'author_id', 'title', 'release_date' ],
+    relationships: {
+      author: {
+        type: 'hasOne',
+        local: 'author_id',
+        foreign: { table: 'user', key: 'id' },
+      },
+    },
   })
 }


### PR DESCRIPTION
Including `relationships` in a `get` is ignoring the query, seemingly because you're not adding `whereSql` in the `withJoin` sub-function.
