### PR TITLE
Removing erroneous `}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ Friendship.prototype.hifive = function () {
 db.table('friendship', {
   fields: [ 'id', 'screen_name', 'friend' ],
   constructor: Friendship
-  }
 })
 ```
 


### PR DESCRIPTION
Code sample is broken. Probably won't affect anyone's usage, but worth fixing.
