### PR TITLE
Fix #10: Empty queries w/relationships shouldn't hang

### DIFF
--- a/lib/drivers/prototype.js
+++ b/lib/drivers/prototype.js
@@ -276,7 +276,7 @@ module.exports = {
     }
   },
   hydrateRow: function (row, opts, callback) {
-    if (isEmpty(opts.relationships))
+    if (!row || isEmpty(opts.relationships))
       return nextTickCallback(callback, null, row)
 
     row = this.fixHasOne(row, {
@@ -296,7 +296,7 @@ module.exports = {
     var waiting = rows.length
     var globalError
 
-    if (isEmpty(opts.relationships))
+    if (!rows.length || isEmpty(opts.relationships))
       return nextTickCallback(callback, null, rows)
 
     rows.forEach(function (row, idx) {

--- a/test/4-get.test.js
+++ b/test/4-get.test.js
@@ -108,6 +108,22 @@ test('table.get, relationships', function (t) {
   })
 })
 
+// https://github.com/brianloveswords/streamsql/issues/10
+test('table.get, relationships should not hang when query returns empty set', function (t) {
+  useDb(t, ['user', 'book'], function (db, done) {
+    const user = makeUserTable(db)
+    const book = makeBookTable(db)
+
+    user.get({ id: 'whatever' }, {
+      debug: true,
+      relationships: true
+    }, function (err, authors) {
+      t.same(authors, [])
+      t.end()
+    })
+  })
+})
+
 // https://github.com/brianloveswords/streamsql/issues/5
 test('table.getOne, should not hang on empty rows', function (t) {
   useDb(t, ['empty'], function (db, done) {


### PR DESCRIPTION
So if a query is made that has `{relationships: true}` **and** it's a `get` (as opposed to `getOne`) **and** that query returns no rows, the query would hang. This fixes that problem.
