### PR TITLE
Nested relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Establish a database connection
 `streamsql` loads drivers on demand and does **not** include them as production dependencies. You will need to have either one `mysql` (tested against `2.0.0-alpha9`) or `sqlite3` (tested against `2.1.19`) in your package.json in addition to `streamsql`.
 
 
-#### mysql optionss
+#### mysql options
 See the [documentation for the mysql module](https://github.com/felixge/node-mysql#establishing-connections) for full details. The `options` object will be passed over to that.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ albums.get([
 * `include`: Rows to select from the database. Any rows not in this list will not be included. Note, the primary key will **always** be included. By default, everything listed in `table.fields` will be included.
 * `exclude`: Rows in this list will not be selected from the database. If both `include` and `exclude` are defined, `include` is always preferred
 * `relationships`: Either boolean or a set of relationship definition.
+* `relationshipsDepth`: Depth of relationships to fulfil; the default is `1` - that is, only the relationships of the requested object are returned. `-1` will attempt to retrieve as many relationships as is reasonably possible.
 * `sort`: Can be one of three forms:
   - Implicit ascending, single column: <code>{sort: 'artist'}</code>
   - Implicit ascending, multiple rows: <code>{sort: ['artist', 'release_date']</code>

--- a/index.js
+++ b/index.js
@@ -131,7 +131,6 @@ tableProto.get = function get(cnd, opts, callback) {
   const tableCache = this.db.tables
 
   const relationships = buildRelationships(this, opts.relationships, opts.relationshipsDepth)
-  console.log('Relationships:...\n%s', JSON.stringify(relationships, null, 2))
   var error = {}
 
   const selectSql = driver.selectSql({

--- a/index.js
+++ b/index.js
@@ -131,8 +131,8 @@ tableProto.get = function get(cnd, opts, callback) {
     relationships = {}
     relationships[relation] = this.relationships[relation]
   } else {
-    // Use no relationships
-    relationships = {}
+    // Use given relationships, or empty if not provided
+    relationships = relationships || {}
   }
 
   relationships = buildRelationships(table, relationships, relationshipsDepth)

--- a/index.js
+++ b/index.js
@@ -130,36 +130,9 @@ tableProto.get = function get(cnd, opts, callback) {
   const table = this.table
   const tableCache = this.db.tables
 
-  var relationshipsDepth = opts.relationshipsDepth
-  var relationships = opts.relationships
+  const relationships = buildRelationships(this, opts.relationships, opts.relationshipsDepth)
+  console.log('Relationships:...\n%s', JSON.stringify(relationships, null, 2))
   var error = {}
-
-  if (typeof relationships == 'boolean' &&
-      relationships === true) {
-    // Use all relationships if `relationships === true`
-    relationships = this.relationships
-  } else if (typeof relationships == 'number') {
-    // Use all relationships
-    relationshipsDepth = relationships
-    relationships = this.relationships
-  } else if (relationships instanceof Array) {
-    // Use subset of relationships if array of keys given
-    relationships = relationships.reduce(function (r, relation) {
-      if (this.relationships.hasOwnProperty(relation))
-        r[relation] = this.relationships[relation]
-      return r
-    }.bind(this), {})
-  } else if (this.relationships.hasOwnProperty(relationships)) {
-    // Use single relationship if key given
-    var relation = relationships
-    relationships = {}
-    relationships[relation] = this.relationships[relation]
-  } else {
-    // Use given relationships, or empty if not provided
-    relationships = relationships || {}
-  }
-
-  relationships = buildRelationships(table, relationships, relationshipsDepth)
 
   const selectSql = driver.selectSql({
     db: this.db,
@@ -214,45 +187,6 @@ tableProto.get = function get(cnd, opts, callback) {
         return new RowClass(row)
       }))
     })
-  }
-
-  function buildRelationships (table, base, depth, history) {
-    if (depth === true)
-      depth = Infinity
-
-    depth = depth === Infinity || depth < 0 ? Infinity : parseInt(depth, 10)
-
-    if (isNaN(depth) || !depth)
-      return base
-
-    history = history || []
-
-    return Object.keys(base).reduce(function (relationships, relation) {
-      const relationship = base[relation]
-      const key = [table, relationship.foreign.table].join(':')
-
-      if (history.indexOf(key) > -1)
-        return relationships
-
-      history.push(key)
-
-      relationship.foreign.as = relationship.foreign.as || relation
-
-      const foreignTable = tableCache[relationship.foreign.table];
-
-      if (foreignTable && (depth - 1))
-        relationship.relationships =
-          buildRelationships(
-            relationship.foreign.table,
-            foreignTable.relationships,
-            depth - 1,
-            history
-          )
-
-      relationships = relationships || {}
-      relationships[relation] = relationship
-      return relationships
-    }, undefined)
   }
 
   if (opts.debug)
@@ -315,12 +249,7 @@ tableProto.createReadStream = function createReadStream(conditions, opts) {
   const fields = this.fields
   const table = this.table
 
-  var relationships = opts.relationships || {}
-
-  if (typeof relationships == 'boolean' &&
-      relationships === true) {
-    relationships = this.relationships
-  }
+  const relationships = buildRelationships(this, opts.relationships, opts.relationshipsDepth)
 
   const selectSql = driver.selectSql({
     db: this.db,
@@ -467,4 +396,74 @@ function getDriver(name) {
   const prototype = require('./lib/drivers/prototype')
   const implementation = drivers[name || 'mysql']()
   return create(prototype, implementation)
+}
+
+function buildRelationships(instance, relationships, depth) {
+  if (typeof relationships == 'boolean' &&
+      relationships === true) {
+    // Use all relationships if `relationships === true`
+    relationships = instance.relationships
+  } else if (typeof relationships == 'number') {
+    // Use all relationships
+    depth = relationships
+    relationships = instance.relationships
+  } else if (relationships instanceof Array) {
+    // Use subset of relationships if array of keys given
+    relationships = relationships.reduce(function (r, relation) {
+      if (instance.relationships.hasOwnProperty(relation))
+        r[relation] = instance.relationships[relation]
+      return r
+    }, {})
+  } else if (instance.relationships.hasOwnProperty(relationships)) {
+    // Use single relationship if key given
+    var relation = relationships
+    relationships = {}
+    relationships[relation] = instance.relationships[relation]
+  } else {
+    // Use given relationships, or empty if not provided
+    relationships = relationships || {}
+  }
+
+  return _buildRelationships(instance.table, relationships, depth, instance.db.tables)
+
+}
+
+function _buildRelationships (table, base, depth, tableCache, history) {
+  if (depth === true)
+    depth = Infinity
+
+  depth = depth === Infinity || depth < 0 ? Infinity : parseInt(depth, 10)
+
+  if (isNaN(depth) || !depth)
+    return base
+
+  history = history || []
+
+  return Object.keys(base).reduce(function (relationships, relation) {
+    const relationship = base[relation]
+    const key = [table, relationship.foreign.table].join(':')
+
+    if (history.indexOf(key) > -1)
+      return relationships
+
+    history.push(key)
+
+    relationship.foreign.as = relationship.foreign.as || relation
+
+    const foreignTable = tableCache[relationship.foreign.table];
+
+    if (foreignTable && (depth - 1))
+      relationship.relationships =
+        _buildRelationships(
+          relationship.foreign.table,
+          foreignTable.relationships,
+          depth - 1,
+          tableCache,
+          history
+        )
+
+    relationships = relationships || {}
+    relationships[relation] = relationship
+    return relationships
+  }, undefined)
 }

--- a/lib/drivers/prototype.js
+++ b/lib/drivers/prototype.js
@@ -284,6 +284,8 @@ module.exports = {
         const parts = relKey.split('.')
         const property = parts.pop()
         const context = parts.reduce(function (context, part) {
+          if (!context[part])
+            context[part] = []
           return context[part]
         }, globalRow);
 

--- a/lib/drivers/prototype.js
+++ b/lib/drivers/prototype.js
@@ -125,17 +125,35 @@ module.exports = {
 
       this.normalizeRelationships(table, relationships)
 
-      // in the loop below, rel -->
-      // { 'type': <string>,
-      //   'local': <{table, key}>,
-      //   'foreign': <{table, key, [as]}>,
-      //   'optional': <null | boolean>  }
+      function addRelationships (relationships, tableAlias) {
+        // in the loop below, rel -->
+        // { 'type': <string>,
+        //   'local': <{table, key}>,
+        //   'foreign': <{table, key, [as]}>,
+        //   'relationships': <{name*: rel}>,
+        //   'optional': <null | boolean>  }
 
-      forEach(relationships, function (rel) {
-        if (rel.type == 'hasMany') return
-        allFields = allFields.concat(getFields(rel.foreign, tables))
-        joinString += this.joinSql(rel)
-      }.bind(this))
+        forEach(relationships, function (rel, name) {
+          if (rel.type == 'hasMany') return
+          var foreignAs = name
+          var localTable = rel.local.table
+
+          rel.foreign.as = tableAlias + JOIN_SEP + foreignAs
+          rel.local.table = tableAlias
+
+          allFields = allFields.concat(getFields(rel.foreign, tables))
+
+          joinString += this.joinSql(rel)
+
+          if (rel.relationships)
+            addRelationships.call(this, rel.relationships, tableAlias + JOIN_SEP + name)
+
+          rel.foreign.as = foreignAs
+          rel.local.table = localTable
+        }.bind(this))
+      }
+
+      addRelationships.call(this, relationships, table)
 
       const selectFields =
         filterFields(allFields, includeFields, excludeFields)
@@ -176,49 +194,39 @@ module.exports = {
     }
 
   },
-  parseJoinRow: function (row, table, relationships) {
+  parseJoinRow: function (row, table) {
     const fixed = {}
 
-    forEach(row, function (val, key) {
-      fixLocalTable(key, fixed)
-      forEach(relationships, function (_, relKey) {
-        fixRelatedTable(key, relKey, fixed)
+    forEach(row, function (value, key) {
+      const parts = key.split(JOIN_SEP)
+      const property = parts.pop()
+      var target = fixed
+      forEach(parts, function (part) {
+        target = (target[part] || (target[part] = {}))
       })
-    })
+      target[property] = value
+    });
 
-    function fixLocalTable(key, fixed) {
-      const tablePrefix = table + JOIN_SEP
-      if (key.indexOf(tablePrefix) !== 0)
-        return
-      fixed[key.replace(tablePrefix, '')] = row[key]
-    }
-
-    function fixRelatedTable(key, relKey, fixed) {
-      const rel = relationships[relKey]
-      const tableName = rel.foreign.as || rel.foreign.table
-      const tablePrefix = tableName + JOIN_SEP
-
-      if (key.indexOf(tablePrefix) !== 0)
-        return
-
-      const subObject = fixed[relKey] || {}
-      const fixedKey = key.replace(tablePrefix, '')
-      subObject[fixedKey] = row[key]
-      fixed[relKey] = subObject
-    }
-
-    return fixed
+    return fixed[table] || {}
   },
   fixHasOne: function (row, opts) {
     const table = opts.table
     const relationships = opts.relationships
     const tableCache = opts.tableCache
-    row = this.parseJoinRow(row, table, relationships)
-    forEach(relationships, function (rel, relKey) {
-      if (rel.type !== 'hasOne') return
-      const foreign = tableCache[rel.foreign.table]
-      row[relKey] = new foreign.constructor(row[relKey])
-    })
+    row = this.parseJoinRow(row, table)
+
+    fixRelationships(row, relationships)
+
+    function fixRelationships (target, relationships) {
+      forEach(relationships, function (rel, relKey) {
+        if (rel.type !== 'hasOne') return
+        const foreign = tableCache[rel.foreign.table]
+        target[relKey] = new foreign.constructor(target[relKey])
+
+        if (rel.relationships)
+          fixRelationships(target[relKey], rel.relationships)
+      })
+    }
 
     return row
   },
@@ -228,10 +236,8 @@ module.exports = {
     const table = opts.table
     const tableCache = opts.tableCache
     const hasMany = {}
-    forEach(opts.relationships, function (rel, relKey) {
-      if (rel.type == 'hasMany')
-        hasMany[relKey] = rel
-    })
+
+    findRelationships(opts.relationships)
 
     if (!keys(hasMany).length) {
       return process.nextTick(function () {
@@ -247,23 +253,41 @@ module.exports = {
       if (globalError) return
       const cond = {}
       const foreign = tableCache[rel.foreign.table]
+      const options = {relationships: rel.relationships || {}}
 
       cond[rel.foreign.key] = globalRow[rel.local.key]
 
-      foreign.get(cond, function (err, rows) {
+      foreign.get(cond, options, function (err, rows) {
         if (globalError) return
         if (err) {
           globalError = err
           return callback(err, null)
         }
 
-        globalRow[relKey] = rows.map(function (row) {
+        const parts = relKey.split('.')
+        const property = parts.pop()
+        const context = parts.reduce(function (context, part) {
+          return context[part]
+        }, globalRow);
+
+        context[property] = rows.map(function (row) {
           return new foreign.constructor(row)
         })
 
         return checkDone()
       })
     })
+
+    function findRelationships (relationships, prefix) {
+      prefix = prefix || ''
+
+      forEach(relationships, function (rel, relKey) {
+        if (rel.type == 'hasMany')
+          hasMany[prefix + relKey] = rel
+        if (rel.relationships)
+          findRelationships(rel.relationships, prefix + relKey + '.')
+      })
+    }
 
     function checkDone() {
       if (globalError) return
@@ -369,7 +393,10 @@ module.exports = {
 
       if (typeof rel.local === 'string')
         rel.local = { table: table, key: rel.local }
-    })
+
+      if (rel.relationships)
+        this.normalizeRelationships(rel.foreign.table, rel.relationships)
+    }.bind(this))
     return relationships
   },
 

--- a/test/4-get.test.js
+++ b/test/4-get.test.js
@@ -64,6 +64,7 @@ test('table.get, relationships', function (t) {
   useDb(t, ['user', 'book'], function (db, done) {
     const user = makeUserTable(db)
     const book = makeBookTable(db)
+    const review = makeReviewTable(db)
 
     book.get({}, {
       debug: true,
@@ -227,6 +228,12 @@ function makeBookTable(db) {
         type: 'hasOne',
         local: 'author_id',
         foreign: { table: 'user', key: 'id' },
+      },
+      reviews: {
+        type: 'hasMany',
+        local: 'id',
+        foreign: { table: 'review', key: 'book_id' },
+        optional: true,
       },
     },
   })

--- a/test/4a-get.test.js
+++ b/test/4a-get.test.js
@@ -106,10 +106,89 @@ test('table.get, relationships', function (t) {
   })
 })
 
+test('table.get, nested relationships', function (t) {
+  sqliteLoad(db, ['user-sqlite', 'book-sqlite', 'review-sqlite'], function () {
+    const user = makeUserTable(db)
+    const book = makeBookTable(db)
+    const review = makeReviewTable(db)
+
+    review.getOne({ id: 1 }, {
+      debug: true,
+      relationships: true,
+      relationshipsDepth: -1
+    }, function (err, review) {
+      t.notOk(err, 'no errors')
+      t.same(review.test(), 'This is a review', 'review is model instance')
+      t.ok(review.book, 'review book returned')
+      t.same(review.book.test(), 'This is a book', 'book is model instance')
+      t.ok(review.book.author, 'review book author returned')
+      t.same(review.book.author.test(), 'This is a user', 'author is model instance')
+      t.ok(review.book.author.books, 'review book author publications returned')
+      t.same(review.book.author.books[0].test(), 'This is a book', 'review book author publications are model instances')
+      t.end()
+    })
+  })
+})
+
 function value(name) { return function (obj) { return obj[name] } }
 
 function makeUserTable(db) {
   return db.table('user', {
     fields: ['id', 'first_name', 'last_name', 'age'],
+    methods: {
+      test: function testUserMethods () {
+        return 'This is a user'
+      }
+    },
+    relationships: {
+      books: {
+        type: 'hasMany',
+        local: 'id',
+        foreign: { table: 'book', key: 'author_id' },
+        optional: true,
+      }
+    },
+  })
+}
+
+function makeBookTable(db) {
+  return db.table('book', {
+    fields: [ 'id', 'author_id', 'title', 'release_date' ],
+    methods: {
+      test: function testBookMethods () {
+        return 'This is a book'
+      }
+    },
+    relationships: {
+      author: {
+        type: 'hasOne',
+        local: 'author_id',
+        foreign: { table: 'user', key: 'id' },
+      },
+      reviews: {
+        type: 'hasMany',
+        local: 'id',
+        foreign: { table: 'review', key: 'book_id' },
+        optional: true,
+      },
+    },
+  })
+}
+
+function makeReviewTable(db) {
+  return db.table('review', {
+    fields: ['id', 'book_id', 'link'],
+    methods: {
+      test: function testReviewMethods () {
+        return 'This is a review'
+      }
+    },
+    relationships: {
+      book: {
+        type: 'hasOne',
+        local: 'book_id',
+        foreign: { table: 'book', key: 'id' },
+      }
+    }
   })
 }

--- a/test/6-createreadstream.test.js
+++ b/test/6-createreadstream.test.js
@@ -123,7 +123,7 @@ test('table.createReadStream: nested relationships', function (t) {
       relationships: true,
       relationshipsDepth: -1
     }).pipe(concat(function (rows) {
-      t.ok(rows[0].book.author, 'should not be undefined') // FAILS
+      t.ok(rows[0].book.author, 'should not be undefined')
       t.end()
     }))
   })


### PR DESCRIPTION
This adds a new property, `relationshipsDepth`, to the query options, which allows relationships to go more than one level deep (which is the default, and current behaviour). Relationships automatically stop if a circular reference is found, regardless of the depth specified.

It also opens up a few new options for `relationships`:
- **Object** - this is the same as it was, and assumes user specified relationships
- **Boolean** - this is the same as it was, and uses any defined relationships if `true`
- **Number** - assumes you meant `relationshipsDepth`, and uses any defined relationships
- **Array** - uses only the specified relationships, as taken from those defined in the model
- **String** - uses the specified relationship, as taken from those defined in the model
