### PR TITLE
Many-to-many relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ id | firstName | lastName
  4 | Britt     | Walford
 ```
 
-**`band_member`** table
+**`bandMember`** table
 
 ```
 id | bandId | memberId
@@ -235,7 +235,7 @@ const member = db.table('member', {
   }
 })
 
-const band_member = db.table('band_member', {
+const bandMember = db.table('bandMember', {
   fields: [ 'bandId', 'memberId' ]
 })
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ You can define relationships on the data coming out `createReadStream` , `get` o
 * `local`: Definition for the left side of the join. If you're just joining on a key normally found in the current table, this can be a string. If you are doing a cascading join (i.e., joining against a field acquired from a different join) you can use an object here:
   * `table`: The name of the table. **Important** if you aliased the table with `as`, use the alias here.
   * `key`: Key to use
+* `via`: Used for many-to-many relationships, where a third table is required to maintain data associations:
+  * `table`: The name of the linking table, as registered with `db.table`.
+  * `local`: The key in the linking table associated with the local table.
+  * `foreign`: The key in the linking table associated with the foreign table.
 * `optional`: Whether or not the relationship is optional (INNER vs LEFT join). Defaults to `false`.
 
 The results of the fulfilled relationship will be attached to the main row by their key in the `relationships` object. All foreign items will have their methods as you defined them when setting up the table with `db.table`, or use their configured `constructor` where applicable.
@@ -155,30 +159,45 @@ The results of the fulfilled relationship will be attached to the main row by th
 **`band`** table
 
 ```
-id | name   | founded | disbanded
----|--------|---------|-----------
- 1 | Slint  |    1986 |      1992
+id | name          | founded | disbanded
+---|---------------|---------|-----------
+ 1 | Squirrel Bait |    1983 |      1988
+ 2 | Slint         |    1986 |      1992
 ```
 
 **`album`** table
 
 ```
-id | bandId | name        | released
----|--------|-------------|----------
- 1 |      1 | Tweez       |     1989
- 2 |      1 | Spiderland  |     1991
+id | bandId | name          | released
+---|--------|---------------|----------
+ 1 |      1 | Squirrel Bait |     1985
+ 2 |      1 | Skag Heaven   |     1987
+ 3 |      2 | Tweez         |     1989
+ 4 |      2 | Spiderland    |     1991
 ```
-
 
 **`member`** table
 
 ```
-id | bandId | firstName | lastName
----|--------|-----------|----------
- 1 |      1 | Brian     | McMahon
- 2 |      1 | David     | Pajo
- 3 |      1 | Todd      | Brashear
- 4 |      1 | Britt     | Walford
+id | firstName | lastName
+---|-----------|----------
+ 1 | Brian     | McMahon
+ 2 | David     | Pajo
+ 3 | Todd      | Brashear
+ 4 | Britt     | Walford
+```
+
+**`band_member`** table
+
+```
+id | bandId | memberId
+---|--------|----------
+ 1 |      1 |        1
+ 2 |      1 |        4
+ 3 |      2 |        1
+ 4 |      2 |        2
+ 5 |      2 |        3
+ 6 |      2 |        4
 ```
 
 
@@ -194,7 +213,8 @@ const band = db.table('band', {
     members: {
       type: 'hasMany',
       local: 'id',
-      foreign: { table: 'member', key: 'bandId' }
+      foreign: { table: 'member', key: 'id' },
+      via: { table: 'bandMember', local: 'bandId', foreign: 'memberId' }
     }
   }
 })
@@ -204,36 +224,58 @@ const album = db.table('album', {
 })
 
 const member = db.table('member', {
-  fields: [ 'bandId', 'firstName', 'lastName' ]
+  fields: [ 'firstName', 'lastName' ],
+  relationships: {
+    bands: {
+      type: 'hasMany',
+      local: 'id',
+      foreign: { table: 'band', key: 'id' },
+      via: { table: 'bandMember', local: 'memberId', foreign: 'bandId' }
+    }
+  }
+})
+
+const band_member = db.table('band_member', {
+  fields: [ 'bandId', 'memberId' ]
 })
 
 // NOTE: for efficiency, relationships are not automatically populated.
 // You must pass { relationships: `true` } to fulfill the relationships
 // defined on the table at time of `get` or `createReadStream`
 
-band.getOne({}, {
+band.get({}, {
   debug: true,
   relationships: true
-}, function (err, row) {
-  console.dir(row)
+}, function (err, rows) {
+  console.dir(rows)
 })
 ```
 
 Will result in:
 
 ```js
-{ id: 1,
-  name: 'Slint',
-  founded: 1986,
-  disbanded: 1992,
-  albums:
-   [ { id: 1, bandId: 1, name: 'Tweez', released: 1989 },
-     { id: 2, bandId: 1, name: 'Spiderland', released: 1991 } ],
-  members:
-   [ { id: 1, bandId: 1, firstName: 'Brian', lastName: 'McMahon' },
-     { id: 2, bandId: 1, firstName: 'David', lastName: 'Pajo' },
-     { id: 3, bandId: 1, firstName: 'Todd', lastName: 'Brashear' },
-     { id: 4, bandId: 1, firstName: 'Britt', lastName: 'Walford' } ] }
+[ { id: 1,
+    name: 'Squirrel Bait',
+    founded: 1983,
+    disbanded: 1988,
+    albums:
+     [ { id: 1, bandId: 1, name: 'Squirrel Bait', released: 1985 },
+       { id: 2, bandId: 1, name: 'Skag Heaven', released: 1987 } ],
+    members:
+     [ { id: 1, firstName: 'Brian', lastName: 'McMahon' },
+       { id: 4, firstName: 'Britt', lastName: 'Walford' } ] },
+  { id: 2,
+    name: 'Slint',
+    founded: 1986,
+    disbanded: 1992,
+    albums:
+     [ { id: 3, bandId: 2, name: 'Tweez', released: 1989 },
+       { id: 4, bandId: 2, name: 'Spiderland', released: 1991 } ],
+    members:
+     [ { id: 1, firstName: 'Brian', lastName: 'McMahon' },
+       { id: 2, firstName: 'David', lastName: 'Pajo' },
+       { id: 3, firstName: 'Todd', lastName: 'Brashear' },
+       { id: 4, firstName: 'Britt', lastName: 'Walford' } ] } ]
 ```
 
 Returns a `table` object.

--- a/lib/drivers/prototype.js
+++ b/lib/drivers/prototype.js
@@ -268,13 +268,8 @@ module.exports = {
 
     forEach(hasMany, function (rel, relKey) {
       if (globalError) return
-      const cond = {}
-      const foreign = tableCache[rel.foreign.table]
-      const options = {relationships: rel.relationships || {}}
 
-      cond[rel.foreign.key] = globalRow[rel.local.key]
-
-      foreign.get(cond, options, function (err, rows) {
+      function handleResult (err, rows) {
         if (globalError) return
         if (err) {
           globalError = err
@@ -290,12 +285,47 @@ module.exports = {
         }, globalRow);
 
         context[property] = rows.map(function (row) {
-          return new foreign.constructor(row)
+          return new rel.foreign.constructor(row)
         })
 
         return checkDone()
-      })
+      }
+
+      (rel.via ? fetchVia : fetchDirect)(rel, handleResult);
     })
+
+    function fetchVia (rel, callback) {
+      const cond = {}
+      const table = tableCache[rel.via.table]
+      const options = {relationships: {}}
+
+      options.relationships[rel.foreign.table] = {
+        type: 'hasOne',
+        local: rel.via.foreign,
+        foreign: rel.foreign
+      }
+
+      cond[rel.via.local] = globalRow[rel.local.key]
+
+      table.get(cond, options, function (err, rows) {
+        if (err)
+          return callback(err);
+
+        return callback(null, rows.map(function (row) {
+          return row[rel.foreign.table];
+        }));
+      })
+    }
+
+    function fetchDirect (rel, callback) {
+      const cond = {}
+      const table = tableCache[rel.foreign.table]
+      const options = {relationships: rel.relationships || {}}
+
+      cond[rel.foreign.key] = globalRow[rel.local.key]
+
+      table.get(cond, options, callback)
+    }
 
     function findRelationships (relationships, prefix) {
       prefix = prefix || ''

--- a/lib/drivers/prototype.js
+++ b/lib/drivers/prototype.js
@@ -302,7 +302,8 @@ module.exports = {
       options.relationships[rel.foreign.table] = {
         type: 'hasOne',
         local: rel.via.foreign,
-        foreign: rel.foreign
+        foreign: rel.foreign,
+        relationships: rel.relationships || {}
       }
 
       cond[rel.via.local] = globalRow[rel.local.key]

--- a/test/4-get.test.js
+++ b/test/4-get.test.js
@@ -313,7 +313,6 @@ function makeViaSecondaryTable(db) {
 
 function makeViaThroughTable(db) {
   return db.table('viaThrough', {
-    primaryKey: 'primary_id',  // Can we make compound keys?
     fields: ['primary_id', 'secondary_id']
   })
 }

--- a/test/sql/via-sqlite.sql
+++ b/test/sql/via-sqlite.sql
@@ -1,0 +1,37 @@
+DROP TABLE IF EXISTS `viaPrimary`;
+CREATE TABLE `viaPrimary` (
+  `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+  `label` VARCHAR(255) NOT NULL
+);
+
+DROP TABLE IF EXISTS `viaSecondary`;
+CREATE TABLE `viaSecondary` (
+  `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+  `label` VARCHAR(255) NOT NULL
+);
+
+DROP TABLE IF EXISTS `viaThrough`;
+CREATE TABLE `viaThrough` (
+  `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+  `primary_id` INTEGER,
+  `secondary_id` INTEGER,
+  UNIQUE (`primary_id`, `secondary_id`)
+);
+
+INSERT INTO `viaPrimary` (`id`, `label`) VALUES
+  (1, 'the'),
+  (2, 'and'),
+  (3, 'to');
+
+INSERT INTO `viaSecondary` (`id`, `label`) VALUES
+  (1, 'as'),
+  (2, 'had'),
+  (3, 'with');
+
+INSERT INTO `viaThrough` (`id`, `primary_id`, `secondary_id`) VALUES
+  (1, 1, 1),
+  (2, 1, 2),
+  (3, 1, 3),
+  (4, 2, 2),
+  (5, 2, 3),
+  (6, 3, 1);

--- a/test/sql/via.sql
+++ b/test/sql/via.sql
@@ -12,25 +12,26 @@ CREATE TABLE `viaSecondary` (
 
 DROP TABLE IF EXISTS `viaThrough`;
 CREATE TABLE `viaThrough` (
+  `id` BIGINT AUTO_INCREMENT PRIMARY KEY,
   `primary_id` BIGINT,
   `secondary_id` BIGINT,
   UNIQUE KEY `first_second` (`primary_id`, `secondary_id`)
 );
 
-INSERT INTO `viaPrimary` (`label`) VALUES
-  ('the'),
-  ('and'),
-  ('to');
+INSERT INTO `viaPrimary` (`id`, `label`) VALUES
+  (1, 'the'),
+  (2, 'and'),
+  (3, 'to');
 
-INSERT INTO `viaSecondary` (`label`) VALUES
-  ('as'),
-  ('had'),
-  ('with');
+INSERT INTO `viaSecondary` (`id`, `label`) VALUES
+  (1, 'as'),
+  (2, 'had'),
+  (3, 'with');
 
-INSERT INTO `viaThrough` (`primary_id`, `secondary_id`) VALUES
-  (1, 1),
-  (1, 2),
-  (1, 3),
-  (2, 2),
-  (2, 3),
-  (3, 1);
+INSERT INTO `viaThrough` (`id`, `primary_id`, `secondary_id`) VALUES
+  (1, 1, 1),
+  (2, 1, 2),
+  (3, 1, 3),
+  (4, 2, 2),
+  (5, 2, 3),
+  (6, 3, 1);

--- a/test/sql/via.sql
+++ b/test/sql/via.sql
@@ -1,0 +1,36 @@
+DROP TABLE IF EXISTS `viaPrimary`;
+CREATE TABLE `viaPrimary` (
+  `id` BIGINT AUTO_INCREMENT PRIMARY KEY,
+  `label` VARCHAR(255) NOT NULL
+);
+
+DROP TABLE IF EXISTS `viaSecondary`;
+CREATE TABLE `viaSecondary` (
+  `id` BIGINT AUTO_INCREMENT PRIMARY KEY,
+  `label` VARCHAR(255) NOT NULL
+);
+
+DROP TABLE IF EXISTS `viaThrough`;
+CREATE TABLE `viaThrough` (
+  `primary_id` BIGINT,
+  `secondary_id` BIGINT,
+  UNIQUE KEY `first_second` (`primary_id`, `secondary_id`)
+);
+
+INSERT INTO `viaPrimary` (`label`) VALUES
+  ('the'),
+  ('and'),
+  ('to');
+
+INSERT INTO `viaSecondary` (`label`) VALUES
+  ('as'),
+  ('had'),
+  ('with');
+
+INSERT INTO `viaThrough` (`primary_id`, `secondary_id`) VALUES
+  (1, 1),
+  (1, 2),
+  (1, 3),
+  (2, 2),
+  (2, 3),
+  (3, 1);


### PR DESCRIPTION
This provides support for many-to-many relationships by allowing `hasMany` relationships to utilise a `via` property.

That is, given the following tables:

``` js
db.table('first', {
  fields: ['id', ...]
  relationships: {
    things: {
      type: 'hasMany',
      local: 'id',
      foreign: { table: 'second', key: 'id' }
    }
  }
})

db.table('second', {
  fields: ['id', ...],
  relationships: {
    things: {
      type: 'hasMany',
      local: 'id',
      foreign: { table: 'first', key: 'id' }
    }
  }
})
```

we can introduce a third table, and add `via` to our relationships to go through that table instead:

``` js
db.table('via', {
  fields: ['first_id', 'second_id']
})

db.table('first', {
  fields: ['id', ...]
  relationships: {
    things: {
      type: 'hasMany',
      local: 'id',
      foreign: { table: 'second', key: 'id' },
      via: { table: 'via', local: 'first_id', foreign: 'second_id' }
    }
  }
})
```

This results in a `first.get(...)` request having a `things` property with many `second` items.
