### PR TITLE
`OR` queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,10 +392,25 @@ albums.get({
 }, function(err, rows){ ... })
 ```
 
-Currently all of the conditions are inclusive – the where statement is joined with `AND` – so the row must match all of the parameters to be included. However, there's a final option that lets you do whatever you want:
+**Simple `OR` queries
+
+All of the examples above are inclusive – the where statement is joined with `AND` – so the row must match all of the parameters to be included. However, by passing in multiple conditions in an array, it is possible to generate an `OR` query.
+```js
+albums.get([
+ {
+   artist: ['Queen', 'Pink Floyd'],
+   release_year: 1975
+ },
+ {
+   artist: ['Electric Light Orchestra', 'Led Zeppelin'],
+   release_year: 1973
+ }
+], function(err, rows){ ... })
+```
 
 **Raw sql**
-Note, you can use `$table` as a placeholder for the current table so you don't have to hardcode it.
+
+There's a final option that lets you do whatever you want. Note, you can use `$table` as a placeholder for the current table so you don't have to hardcode it.
 ```js
 albums.get([
   'SELECT `release_date` AS `date` FROM $table WHERE `title` = ? AND `artist`= ?',

--- a/lib/drivers/prototype.js
+++ b/lib/drivers/prototype.js
@@ -14,49 +14,70 @@ module.exports = {
     return sqlstring.escapeId(id)
   },
   whereSql: function whereSql(table, conditions) {
-    const hasConditons = conditions && keys(conditions).length
-    if (!hasConditons) return ''
-
     const escape = this.escape
     const escapeId = this.escapeId
-    var where = ' WHERE '
-    var error
 
-    var clauses = map(conditions, function (val, key) {
-      const field = escapeId([table, key].join('.'))
-      var cnd = conditions[key]
+    try {
+      var sql = build(conditions)
+      if (sql) sql = ' WHERE ' + sql
+      return sql
+    } catch (e) {
+      return e;
+    }
 
-      if (Array.isArray(cnd)) {
-        // if the condition is a simple array,
-        // e.g { release_date: [2000,1996] }
-        // use an `in` operator.
-        if (typeof cnd[0] != 'object') {
-          cnd = cnd.map(function (x) { return escape(x) })
-          return fmt('%s IN (%s)', field, cnd.join(','))
+    function build (conditions) {
+      if (!Array.isArray(conditions))
+        return generateSql(conditions)
+
+      const groups = conditions.map(function (subset) {
+        return '(' + build(subset) + ')'
+      })
+
+      // it's unclear as to whether a {} subset query should be
+      // included or not - does `get([{id:1}, {}])` return everything,
+      // or should the {} be ignored?
+      // for now, we're eliminating empty groups
+      return groups.join(' OR ').replace(/\s*OR \(\s*\)/, '')
+    }
+
+    function generateSql (conditions) {
+      const hasConditons = conditions && keys(conditions).length
+      if (!hasConditons) return ''
+
+      const clauses = map(conditions, function (val, key) {
+        const field = escapeId([table, key].join('.'))
+        var cnd = conditions[key]
+
+        if (Array.isArray(cnd)) {
+          // if the condition is a simple array,
+          // e.g { release_date: [2000,1996] }
+          // use an `in` operator.
+          if (typeof cnd[0] != 'object') {
+            cnd = cnd.map(function (x) { return escape(x) })
+            return fmt('%s IN (%s)', field, cnd.join(','))
+          }
+
+          return cnd.map(function (subcnd) {
+            const operation = subcnd.op
+            const value = escape(subcnd.value)
+            return fmt('%s %s %s', field, operation, value)
+          }).join(' AND ')
         }
 
-        return cnd.map(function (subcnd) {
-          const operation = subcnd.op
-          const value = escape(subcnd.value)
-          return fmt('%s %s %s', field, operation, value)
-        }).join(' AND ')
-      }
+        if (cnd !== null) {
+          if (typeof cnd == 'undefined')
+            throw new RangeError('Condition for `'+key+'` cannot be undefined')
 
-      if (cnd !== null) {
-        if (typeof cnd == 'undefined')
-          return (error = new RangeError('Condition for `'+key+'` cannot be undefined'))
+          const op = cnd.operation || cnd.op || '='
+          if (cnd.value) cnd = cnd.value
+          return fmt('%s %s %s', field, op, escape(cnd))
+        }
 
-        const op = cnd.operation || cnd.op || '='
-        if (cnd.value) cnd = cnd.value
-        return fmt('%s %s %s', field, op, escape(cnd))
-      }
+        return fmt('%s IS NULL', field)
+      })
 
-      return fmt('%s IS NULL', field)
-    })
-
-    if (error) return error
-    where += clauses.join(' AND ')
-    return where
+      return clauses.join(' AND ')
+    }
   },
   orderSql: function orderSql(table, order) {
     if (!order) return ''
@@ -98,7 +119,8 @@ module.exports = {
     const includeFields = opts.include
     const excludeFields = opts.exclude
     const relationships = opts.relationships
-    const useRaw = Array.isArray(conds) || typeof conds === 'string'
+    const useRaw = (Array.isArray(conds) && typeof conds[0] === 'string')
+                   || typeof conds === 'string'
     const useJoin = (relationships && keys(relationships).length)
 
     if (useRaw) return rawSql.call(this)

--- a/test/4-get.test.js
+++ b/test/4-get.test.js
@@ -160,6 +160,23 @@ test('table.get, many-to-many relationships', function (t) {
   })
 })
 
+test('table.get, OR query', function (t) {
+  useDb(t, ['user'], function (db, done) {
+    const user = makeUserTable(db)
+
+    user.get([{age: {value: 65, operation: '>='}}, {first_name: 'George'}], {
+      debug: true
+    }, function (err, rows) {
+      t.notOk(err, 'No errors')
+      t.same(rows.length, 2)
+      t.same(rows[0].first_name, 'George')
+      t.same(rows[1].first_name, 'Barry')
+
+      t.end()
+    });
+  })
+})
+
 // https://github.com/brianloveswords/streamsql/issues/10
 test('table.get, relationships should not hang when query returns empty set', function (t) {
   useDb(t, ['user', 'book'], function (db, done) {

--- a/test/4a-get.test.js
+++ b/test/4a-get.test.js
@@ -156,6 +156,22 @@ test('table.get, many-to-many relationships', function (t) {
   })
 })
 
+test('table.get, OR query', function (t) {
+  sqliteLoad(db, ['user-sqlite'], function () {
+    const user = makeUserTable(db)
+
+    user.get([{age: {value: 65, operation: '>='}}, {first_name: 'George'}], {
+      debug: true
+    }, function (err, rows) {
+      t.same(rows.length, 2)
+      t.same(rows[0].first_name, 'George')
+      t.same(rows[1].first_name, 'Barry')
+
+      t.end()
+    });
+  })
+})
+
 function value(name) { return function (obj) { return obj[name] } }
 
 function makeUserTable(db) {

--- a/test/5-del.test.js
+++ b/test/5-del.test.js
@@ -1,13 +1,15 @@
 const test = require('tap').test
 const useDb = require('./testdb')
 
-test('table.get', function (t) {
+test('table.del', function (t) {
   useDb(t, ['user'], function (db, done) {
     const user = db.table('user', {
       fields: ['first_name', 'last_name'],
     })
 
-    user.del({haunted: null, last_name: 'Hannah'}, function (err, result) {
+    user.del({haunted: null, last_name: 'Hannah'}, {
+      debug: true
+    }, function (err, result) {
       t.notOk(err, 'no errors')
       t.same(result.affectedRows, 1, 'should affect one row')
 
@@ -15,6 +17,23 @@ test('table.get', function (t) {
         t.same(rows, [], 'should have no results')
         t.end()
       })
+    })
+  })
+})
+
+test('table.del, OR query', function (t) {
+  useDb(t, ['user'], function (db, done) {
+    const user = db.table('user', {
+      fields: ['first_name', 'last_name'],
+    })
+
+    user.del([{age: {value: 65, operation: '>='}}, {first_name: 'George'}], {
+      debug: true
+    }, function (err, result) {
+      t.notOk(err, 'No errors')
+      t.same(result.affectedRows, 2, 'should affect two rows')
+
+      t.end()
     })
   })
 })

--- a/test/5a-del.test.js
+++ b/test/5a-del.test.js
@@ -24,3 +24,20 @@ test('table.get', function (t) {
     })
   })
 })
+
+test('table.get, OR query', function (t) {
+  sqliteLoad(db, ['user-sqlite'], function () {
+    const user = db.table('user', {
+      fields: ['first_name', 'last_name'],
+    })
+
+    user.del([{age: {value: 65, operation: '>='}}, {first_name: 'George'}], {
+      debug: true
+    }, function (err, result) {
+      t.notOk(err, 'No errors')
+      t.same(result.affectedRows, 2, 'should affect two rows')
+
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
Adding `OR` functionality to `WHERE` queries - `... WHERE (<clause 1>) OR (<clause 2>) ...`:

```
table.get([{...}, {...}], ...)
```

Scratching my head as to how `... WHERE <clause 1> AND ((<clause 2>) OR (<clause 3>)) ...` might be enabled, but I think this is a step in the right direction.
