### PR TITLE
Query sorting

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ tableProto.get = function get(cnd, opts, callback) {
     include: opts.include,
     exclude: opts.exclude,
     page: opts.page,
-    order: opts.order || opts.orderBy,
+    order: opts.sort || opts.order || opts.orderBy,
   })
 
   if (typeof selectSql == 'object' && selectSql.name == 'RangeError') {

--- a/test/4-get.test.js
+++ b/test/4-get.test.js
@@ -38,7 +38,7 @@ test('table.get, complex where', function (t) {
       sort: 'age',
       debug: true
     }, function (err, rows) {
-      const expect = ['Saunders', 'Link']
+      const expect = ['Link', 'Saunders']
       const result = rows.map(value('last_name'))
       t.same(result, expect, 'should have the right values')
       t.end()

--- a/test/4-get.test.js
+++ b/test/4-get.test.js
@@ -26,6 +26,26 @@ test('table.get', function (t) {
   })
 })
 
+test('table.get, ordering', function (t) {
+  useDb(t, ['user'], function (db, done) {
+    const user = makeUserTable(db)
+
+    user.get({}, {
+      sort: {age: 'desc'},
+      debug: true
+    }, function (err, rows) {
+      t.notOk(err, 'No error thrown')
+      t.ok(rows[0].age > rows[1].age, 'Sorted by age descending')
+
+      user.get({}, {order: {age: 'desc'}}, function (err, moreRows) {
+        t.deepEquals(rows, moreRows, '`sort` and `order` synonymous')
+
+        t.end()
+      })
+    })
+  })
+})
+
 test('table.get, complex where', function (t) {
   useDb(t, ['user'], function (db, done) {
     const user = makeUserTable(db)

--- a/test/4a-get.test.js
+++ b/test/4a-get.test.js
@@ -46,7 +46,7 @@ test('table.get, complex where', function (t) {
       sort: 'age',
       debug: true
     }, function (err, rows) {
-      const expect = ['Saunders', 'Link']
+      const expect = ['Link', 'Saunders']
       const result = rows.map(value('last_name'))
       t.same(result, expect, 'should have the right values')
       t.end()

--- a/test/4a-get.test.js
+++ b/test/4a-get.test.js
@@ -34,6 +34,26 @@ test('table.get', function (t) {
   })
 })
 
+test('table.get, ordering', function (t) {
+  sqliteLoad(db, ['user-sqlite'], function () {
+    const user = makeUserTable(db)
+
+    user.get({}, {
+      sort: {age: 'desc'},
+      debug: true
+    }, function (err, rows) {
+      t.notOk(err, 'No error thrown')
+      t.ok(rows[0].age > rows[1].age, 'Sorted by age descending')
+
+      user.get({}, {order: {age: 'desc'}}, function (err, moreRows) {
+        t.deepEquals(rows, moreRows, '`sort` and `order` synonymous')
+
+        t.end()
+      })
+    })
+  })
+})
+
 test('table.get, complex where', function (t) {
   sqliteLoad(db, ['user-sqlite'], function () {
     const user = makeUserTable(db)


### PR DESCRIPTION
Sorting is broken (see #20), not because it doesn't work, but because the docs say `sort` and the code says `order`. Given that the tests are using `sort` too, I'm assuming that is what is expected, so adding it to the possible ordering values rather than 'fixing' the docs.
