### PR TITLE
Match docs for multiple conditions on single column

### DIFF
--- a/lib/drivers/prototype.js
+++ b/lib/drivers/prototype.js
@@ -58,7 +58,7 @@ module.exports = {
           }
 
           return cnd.map(function (subcnd) {
-            const operation = subcnd.op
+            const operation = subcnd.op || subcnd.operation
             const value = escape(subcnd.value)
             return fmt('%s %s %s', field, operation, value)
           }).join(' AND ')


### PR DESCRIPTION
Code expects `op: '>='` but docs say `operation: '>='`:

``` js
albums.get({
  artist: 'David Bowie',
  release_year: [{
    operation: '>=',
    value: 1976
  }, {
    operation: '<='
    value: 1978
  }]
}, function(err, rows){ ... })
```
